### PR TITLE
Add Dockerfile implementation for luacheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (C) 2019 Martin Broers <martin.broers@evbox.com>
+
+# For Alpine, latest is actually the latest stable
+# hadolint ignore=DL3007
+FROM registry.hub.docker.com/library/alpine:latest
+
+LABEL Maintainer="Martin Broers <martin.broers@evbox.com>"
+
+# We want the latest stable version from the repo
+# hadolint ignore=DL3018
+RUN \
+    apk add --no-cache \
+        dumb-init \
+        lua-argparse \
+        lua-filesystem \
+        luacheck \
+    && \
+    rm -rf "/var/cache/apk/"* && \
+    for luacheckfile in $(apk info -L luacheck); do \
+        if [ -f "/${luacheckfile}" ]; then \
+            rm "/${luacheckfile:?}"; \
+        fi \
+    done
+
+COPY "src/luacheck/" "/usr/share/lua/5.1/luacheck/"
+COPY "bin/luacheck.lua" "/usr/bin/luacheck"
+
+COPY "scripts/docker-entrypoint.sh" "/docker-entrypoint.sh"
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -114,6 +114,28 @@ Use the Luacheck issue tracker on GitHub to submit bugs, suggestions and questio
 
 After the Luacheck repo is cloned and changes are made, run `luarocks make` (using `sudo` if necessary) from its root directory to install dev version of Luacheck. To run Luacheck using sources in current directory without installing it, run `lua -e 'package.path="./src/?.lua;./src/?/init.lua;"..package.path' bin/luacheck.lua ...`. To test Luacheck, ensure that you have [busted](http://olivinelabs.com/busted/) and [luautf8](https://github.com/starwing/luautf8) installed and run `busted`.
 
+## Docker
+Luacheck can be run inside a docker container, so it can be distributed across
+different platforms and can be run against any source directory. The usage of
+docker is fairly simple by executing the following two commands, the container
+will be built and be run in any source directory applicable:
+
+Execute the following command in the root directory of this repository:
+`docker build -t luacheck:latest .`
+
+Or, just to pull the image from the public DockerHub repositories, execute:
+`docker pull martinbrothers/luacheck:latest`
+
+To run the docker, execute this command in the source directory to be linted:
+`docker run --rm -v $(pwd):/workdir luacheck:latest`.
+
+For example, to run luacheck on itself:
+`docker run --rm -v $(pwd):/workdir luacheck:latest luacheck bin/luacheck.lua`
+
+Note, while the script supports omitting the 'luacheck' command in true docker
+image consitency fashion,  if the script however to be linted is an executable,
+this fails (as the container will try to execute the executable).
+
 ## License
 
 ```

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/dumb-init /bin/sh
+# SPDX-License-Identifier: MIT
+#
+# Copyright (C) 2019 Martin Broers <martin.broers@evbox.com>
+#
+# A beginning user should be able to docker run image bash (or sh) without
+# needing to learn about --entrypoint
+# https://github.com/docker-library/official-images#consistency
+
+set -eu
+
+# run command if it is not starting with a "-" and is an executable in PATH
+if [ "${#}" -gt 0 ] && \
+    [ "${1#-}" = "${1}" ] && \
+    command -v "${1}"; then
+    exec "${@}"
+else
+    # else default to run command with luacheck
+    exec luacheck "${@}"
+fi


### PR DESCRIPTION
A simple Dockerfile pulls in the repository and builds the repo inside the
container. The container hence will always contain the latest version of the
master branch. The container can be used to check any lua source folder without
installing any of the dependencies on the host operating system, making it an
ideal tool for CI integration.

To build it locally:
`docker build -t luacheck:latest .`
To run it locally:
`docker run -it --rm -v '$(pwd):/workdir' -w /workdir luacheck:latest`