### PR TITLE
Add pre-commit hook to enable Luacheck for pre-commit.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: luacheck
+    name: Luacheck
+    description: Lint and static analysis of Lua code
+    entry: luacheck
+    language: lua
+    types: [lua]


### PR DESCRIPTION
Hello! I've been working with the maintainer of [pre-commit](https://pre-commit.com/) to add official Lua support for the pre-commit tool. With pre-commit, a developer or team can choose to run hooks that will execute before a change is committed to git.

Support for Lua in pre-commit was literally added an hour ago as of this PR submission in https://github.com/pre-commit/pre-commit/pull/2158, so this change is hot off the presses.

I believe that Luacheck would be a fantastic tool to work with pre-commit since running lint checks is a very common thing to do before committing.

This PR adds a hooks definition file that will allow any project to use Luacheck with pre-commit. I ran a local test on one of my projects to confirm the behavior. I've included the failing and passing output below to show that the hook is working.

Thanks for the consideration.

Failing output:
```bash
atlas git:(main) ✗ pre-commit try-repo ../luacheck luacheck
===============================================================================
Using config:
===============================================================================
repos:
-   repo: ../luacheck
    rev: 07cee87da56787e005b35019ddaa5eadf127655b
    hooks:
    -   id: luacheck
===============================================================================
[INFO] Initializing environment for ../luacheck.
[INFO] Installing environment for ../luacheck.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Luacheck.................................................................Failed
- hook id: luacheck
- exit code: 1

Checking src/atlas/main.lua                       3 warnings

    src/atlas/main.lua:19:9: unused variable parser
    src/atlas/main.lua:20:9: variable parser is never set
    src/atlas/main.lua:20:9: variable parser was previously defined on line 19

Total: 3 warnings / 0 errors in 1 file

```

Passing output:
```bash
pre-commit try-repo ../luacheck luacheck
===============================================================================
Using config:
===============================================================================
repos:
-   repo: ../luacheck
    rev: 07cee87da56787e005b35019ddaa5eadf127655b
    hooks:
    -   id: luacheck
===============================================================================
[INFO] Initializing environment for ../luacheck.
[INFO] Installing environment for ../luacheck.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Luacheck.................................................................Passed
```