### PR TITLE
Function without any home envirenment vars

### DIFF
--- a/src/luacheck/cache.lua
+++ b/src/luacheck/cache.lua
@@ -52,6 +52,7 @@ function cache.get_default_dir()
          end
       end
    end
+   return fs.join(fs.get_current_dir(), ".luacheck_cache")
 end
 
 local format_version = "1"


### PR DESCRIPTION
Closes #51

Previously even when `--no-cache` was set, we were trying to evaluate a default value for `--cache` based on `$HOME` or `$XDG_CACHE_HOME`. In the event neither was set (as happens for example in some hook environments) we were failing to even parse a default value.

This adds another fallback if those home environments done provide a hint about where to put the cache: we just put it in the current directory.

Notably having this as a fallback default also allows `--no-cache` to work, since we can reliably get past setting a default cache config option we also get to the point where we can disable it. If writing to the CWD is not desired (e.g. from SVN hooks) either set a preferred location or disable the cache.
