### PR TITLE
Add support for ldoc globals builtin

### DIFF
--- a/docsrc/cli.rst
+++ b/docsrc/cli.rst
@@ -86,6 +86,7 @@ Option                                  Meaning
                                         * ``busted`` - globals added by Busted 2.0, by default added for files ending with ``_spec.lua`` within ``spec``, ``test``, and ``tests`` subdirectories;
                                         * ``rockspec`` - globals allowed in rockspecs, by default added for files ending with ``.rockspec``;
                                         * ``luacheckrc`` - globals allowed in Luacheck configs, by default added for files ending with ``.luacheckrc``;
+                                        * ``ldoc`` - globals allowed in LDoc config;
                                         * ``none`` - no standard globals.
 
                                         See :ref:`stds`

--- a/docsrc/cli.rst
+++ b/docsrc/cli.rst
@@ -86,7 +86,7 @@ Option                                  Meaning
                                         * ``busted`` - globals added by Busted 2.0, by default added for files ending with ``_spec.lua`` within ``spec``, ``test``, and ``tests`` subdirectories;
                                         * ``rockspec`` - globals allowed in rockspecs, by default added for files ending with ``.rockspec``;
                                         * ``luacheckrc`` - globals allowed in Luacheck configs, by default added for files ending with ``.luacheckrc``;
-                                        * ``ldoc`` - globals allowed in LDoc config;
+                                        * ``ldoc`` - globals allowed in LDoc config, by default added for files named ``config.ld``;
                                         * ``none`` - no standard globals.
 
                                         See :ref:`stds`

--- a/docsrc/config.rst
+++ b/docsrc/config.rst
@@ -191,5 +191,6 @@ Default per-path std overrides
    files["**/tests/**/*_spec.lua"].std = "+busted"
    files["**/*.rockspec"].std = "+rockspec"
    files["**/*.luacheckrc"].std = "+luacheckrc"
+   files["**/config.ld"].std = "+ldoc"
 
 Each of these can be overriden by setting a different ``std`` value for the corresponding key in ``files``.

--- a/src/luacheck/builtin_standards/init.lua
+++ b/src/luacheck/builtin_standards/init.lua
@@ -315,6 +315,25 @@ builtin_standards.luacheckrc = {
    }
 }
 
+builtin_standards.ldoc = {
+   globals = {
+      -- Fields from cli parameters
+      "file", "project", "title", "package", "all", "format", "output", "dir", "colon", "boilerplate", "ext", "one",
+      "style", "template", "merge", "icon",
+      -- `config.ld` additional fields
+      "description", "full_description", "examples", "readme", "topics", "pretty", "prettify_files", "charset", "sort",
+      "no_return_or_parms", "no_lua_ref", "backtick_references", "plain", "wrap", "manual_url", "no_summary",
+      "custom_tags", "custom_see_handler", "custom_display_name_handler", "not_luadoc", "no_space_before_args",
+      "template_escape", "user_keywords", "postprocess_html",
+      -- Available functions
+      "alias", "add_language_extension", "add_section", "new_type", "tparam_alias", "custom_see_handler",
+      -- "Undocumented" fields
+      "kind_names", "topics", "unqualified", "dont_escape_underscore", "custom_css", "version", "no_args_infer",
+      "parse_extra", "output", "dir", "charset", "ignore", "module_file", "vars", "wrap", "not_luadoc",
+      "merge_error_groups", "sort_modules", "use_markdown_titles", "custom_references", "global_lookup", "convert_opt"
+   }
+}
+
 builtin_standards.none = {}
 
 return builtin_standards

--- a/src/luacheck/config.lua
+++ b/src/luacheck/config.lua
@@ -228,6 +228,7 @@ local function add_default_path_options(opts)
    set_default_std(files, "**/tests/**/*_spec.lua", "+busted")
    set_default_std(files, "**/*.rockspec", "+rockspec")
    set_default_std(files, "**/*.luacheckrc", "+luacheckrc")
+   set_default_std(files, "**/config.ld", "+ldoc")
 end
 
 local fallback_config = {options = {}, anchor_dir = ""}


### PR DESCRIPTION
This adds initial support for the ldoc global builtin fields and functions as listed at https://github.com/lunarmodules/LDoc/blob/38b1537d1fa78fcf11668d2f1dd556fec8c417c8/doc/doc.md#fields-allowed-in-configld.

I think this is useful for luacheck, because it allows to include any ldoc `config.ld` file to be linted by luacheck easily.

Currently, the user need to manually declare (or ignore) to luacheck each builtin field used in a ldoc configuration file.  With this new builtin_standards, the user can simply add `files["path/to/config.ld"].std = "+ldoc"` to their `.luacheckrc` and they are done.