### PR TITLE
Add builtin rule set for SILE globals

### DIFF
--- a/docsrc/cli.rst
+++ b/docsrc/cli.rst
@@ -87,6 +87,7 @@ Option                                  Meaning
                                         * ``rockspec`` - globals allowed in rockspecs, by default added for files ending with ``.rockspec``;
                                         * ``luacheckrc`` - globals allowed in Luacheck configs, by default added for files ending with ``.luacheckrc``;
                                         * ``ldoc`` - globals allowed in LDoc config, by default added for files named ``config.ld``;
+                                        * ``sile`` - globals allowed in The SILE Typesetter and its package ecosystem;
                                         * ``none`` - no standard globals.
 
                                         See :ref:`stds`

--- a/src/luacheck/builtin_standards/init.lua
+++ b/src/luacheck/builtin_standards/init.lua
@@ -334,6 +334,12 @@ builtin_standards.ldoc = {
    }
 }
 
+builtin_standards.sile = {
+   globals = {
+      "SILE", "SU", "luautf8", "pl", "fluent", "CASILE"
+   }
+}
+
 builtin_standards.none = {}
 
 return builtin_standards


### PR DESCRIPTION
[The SILE Typesetter](https://sile-typesetter.org/) is a typesetting engine written in Lua — and more relevant to this PR extended in Lua. Having these globals setup in the `.luacheckrc` for the upstream project worked fine for project development, but it isn't so convenient for package developers. That only included a handful of projects until we released [v0.14.0](https://sile-typesetter.org/blog/release-v0.14.0/) which started supporting 3rd party addons installed via LuaRocks. Now SILE packages are starting to proliferate.

I'm starting to work through what it looks like to test a 3rd party package properly, but low hanging fruit is to start by linting. Since the allowed global scope is pretty restricted this is a pretty small builtin set. Someday if upstream commits to public vs. private properties and documentation improves it could be expanded to cover more details about read/write etc., but for now just checking for global access would be nice.
