### PR TITLE
build: add luarocks.lock

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -40,7 +40,7 @@ jobs:
           luarocks install --deps-only luacheck-dev-1.rockspec
 
       - name: Build ‘luacheck’ (bootstrap)
-        run: luarocks make --pin
+        run: luarocks make
 
       - name: Run ‘luacheck’ (dogfood)
         run: luacheck .

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -40,7 +40,7 @@ jobs:
           luarocks install --deps-only luacheck-dev-1.rockspec
 
       - name: Build ‘luacheck’ (bootstrap)
-        run: luarocks make
+        run: luarocks make --pin
 
       - name: Run ‘luacheck’ (dogfood)
         run: luacheck .

--- a/luarocks.lock
+++ b/luarocks.lock
@@ -1,0 +1,7 @@
+return {
+   dependencies = {
+      argparse = "0.7.1-1",
+      lua = "5.4-1",
+      luafilesystem = "1.8.0-1"
+   },
+}


### PR DESCRIPTION
Lockfile is a way to ensure [the repeatable build](https://github.com/luarocks/luarocks/wiki/Pinning-versions-with-a-lock-file), thus adding the lockfile and update make builds to use `--pin`

also relates to https://github.com/Homebrew/homebrew-core/pull/117684