### PR TITLE
Removed unnecessary symbol from Playdate std

### DIFF
--- a/src/luacheck/builtin_standards/playdate.lua
+++ b/src/luacheck/builtin_standards/playdate.lua
@@ -135,7 +135,6 @@ local playdate = {
       argv = empty,
       setNewlinePrinted = empty,
       drawFPS = empty,
-      exit = empty,
 
       -- Profiling
       getStats = empty,


### PR DESCRIPTION
This, it turns out, is not needed.