### PR TITLE
Fix warning 582 (error prone negation) not applying to subexpressions

### DIFF
--- a/spec/check_spec.lua
+++ b/spec/check_spec.lua
@@ -331,12 +331,34 @@ end
 ]])
    end)
 
-   it("warns about error-prone negations", function()
-      assert.same({
-         {code = "582", line = 1, column = 13, end_column = 21}
-      }, check[[
-         if not 5 > 5 then return end
+   describe("error-prone negations", function()
+      it("as sole conditions", function()
+         assert.same({
+            {code = "582", line = 1, column = 16, end_column = 24}
+         }, check[[
+            if not 5 > 5 then return end
 ]])
+      end)
+
+      it("as subexpressions", function()
+         assert.same({
+            {code = "582", line = 1, column = 25, end_column = 34}
+         }, check[[
+            if not 5 or not 5 == 5 then return end
+]])
+      end)
+
+      it("doesn't warn if properly parenthesized", function()
+         assert.same({}, check[[
+            if (not 5) == 5 then return end
+]])
+      end)
+
+      it("doesn't warn for a literal 'not'", function()
+         assert.same({}, check[[
+            if 5 == "not" then return end
+]])
+      end)
    end)
 
    it("doesn't warn on similarly named variables", function()

--- a/src/luacheck/stages/unwrap_parens.lua
+++ b/src/luacheck/stages/unwrap_parens.lua
@@ -54,14 +54,13 @@ local function handle_nodes(chstate, nodes, list_start)
             handle_nodes(chstate, node[1])
             handle_nodes(chstate, node[2], 1)
          else
-            -- warn that not x == y means (not x) == y
-            if tag ~= "Paren"
-               and node[1]
-               and node[1].tag == "Op"
-               and relational_operators[node[1][1]]
-               and node[1][2][1] == "not"
+            -- warn that not x <relop> y means (not x) <relop> y
+            if tag == "Op"
+               and relational_operators[node[1]]
+               and node[2].tag == "Op"
+               and node[2][1] == "not"
             then
-               chstate:warn_range("582", node[1])
+               chstate:warn_range("582", node)
             end
 
             handle_nodes(chstate, node)


### PR DESCRIPTION
This fixes warning 582 not applying properly to subexpressions; the checks were applied to `node[1]` rather than directly to `node`. Furthermore it also checks for `x == not y` now; I've also added some tests for some variants of the error prone negation.

See https://github.com/minetest/minetest_game/pull/3032#issuecomment-1556037064 for the motivation behind this.