### PR TITLE
Compound bugfix

### DIFF
--- a/spec/cli_spec.lua
+++ b/spec/cli_spec.lua
@@ -300,8 +300,8 @@ Total: 5 warnings / 0 errors in 1 file
 
     spec/samples/compound_operators.lua:2:1: assignment uses compound operator +=
     spec/samples/compound_operators.lua:3:1: assignment uses compound operator -=
-    spec/samples/compound_operators.lua:4:1: assignment uses compound operator *=
-    spec/samples/compound_operators.lua:5:1: assignment uses compound operator /=
+    spec/samples/compound_operators.lua:5:2: assignment uses compound operator /=
+    spec/samples/compound_operators.lua:10:1: assignment uses compound operator *=
 
 Total: 0 warnings / 4 errors in 1 file
 ]], get_output "spec/samples/compound_operators.lua --no-config")
@@ -311,8 +311,8 @@ Total: 0 warnings / 4 errors in 1 file
       assert.equal([[Checking spec/samples/compound_operators.lua      3 errors
 
     spec/samples/compound_operators.lua:3:1: assignment uses compound operator -=
-    spec/samples/compound_operators.lua:4:1: assignment uses compound operator *=
-    spec/samples/compound_operators.lua:5:1: assignment uses compound operator /=
+    spec/samples/compound_operators.lua:5:2: assignment uses compound operator /=
+    spec/samples/compound_operators.lua:10:1: assignment uses compound operator *=
 
 Total: 0 warnings / 3 errors in 1 file
 ]], get_output "spec/samples/compound_operators.lua --no-config --operators +=")

--- a/spec/samples/compound_operators.lua
+++ b/spec/samples/compound_operators.lua
@@ -1,6 +1,11 @@
 local i = 0
 i += 10
 i -= 5
-i *= 2
-i /= 5
-return i
+local function func()
+	i /= 5
+end
+func()
+local t = {}
+t.a = i
+t.a *= 2
+return t

--- a/src/luacheck/parser.lua
+++ b/src/luacheck/parser.lua
@@ -931,7 +931,7 @@ local function parse_expression_statement(state)
          parse_error(state, "compound assignment not allowed on tuples near " .. compound_operator .. "=")
       end
 
-      return new_inner_node(start_range, rhs[1], "OpSet", {compound_operator, lhs[1], rhs[1]})
+      return new_inner_node(start_range, rhs[1], "OpSet", {lhs, rhs, compound_operator})
    else
       -- This is an assignment in the form `lhs = rhs`.
       check_and_skip_token(state, "=")

--- a/src/luacheck/stages/detect_compound_operators.lua
+++ b/src/luacheck/stages/detect_compound_operators.lua
@@ -23,7 +23,7 @@ local reverse_compound_operators = {
 }
 
 local function check_node(chstate, node)
-    local operator = reverse_compound_operators[node[1]]
+    local operator = reverse_compound_operators[node[3]]
     chstate:warn_range("033", node, {operator = operator})
 end
 

--- a/src/luacheck/stages/detect_globals.lua
+++ b/src/luacheck/stages/detect_globals.lua
@@ -234,7 +234,7 @@ local function detect_globals_in_line(chstate, line)
          if item.rhs then
             detect_in_nodes(chstate, item, item.rhs, is_top_line)
          end
-      elseif item.tag == "Set" then
+      elseif item.tag == "Set" or item.tag == "OpSet" then
          detect_in_nodes(chstate, item, item.lhs, is_top_line, true)
          detect_in_nodes(chstate, item, item.rhs, is_top_line)
       end

--- a/src/luacheck/stages/resolve_locals.lua
+++ b/src/luacheck/stages/resolve_locals.lua
@@ -95,19 +95,24 @@ local function contains_call(node)
 end
 
 local function is_circular_reference(item, var)
+   -- OpSet is circular by definition
+   if not (item.tag == "Set" or item.tag == "Local") then
+      return false
+   end
+
    -- No support for matching multiple assignment to the specific assignment
-   if not (item.tag == "Set" or item.tag == "Local" or item.tag == "OpSet") then
+   if not item.lhs or #item.lhs ~= 1 or not item.rhs or #item.rhs ~= 1 then
       return false
    end
 
    -- Case t[t.function()] = t.func()
    -- Functions can have side-effects, so this isn't purely circular
-   local right_assignment = item.tag == "OpSet" and item.rhs or item.rhs[1]
+   local right_assignment = item.rhs[1]
    if contains_call(right_assignment) then
       return false
    end
 
-   local left_assignment = item.tag == "OpSet" and item.lhs or item.lhs[1]
+   local left_assignment = item.lhs[1]
    if contains_call(left_assignment) then
       return false
    end

--- a/src/luacheck/stages/unwrap_parens.lua
+++ b/src/luacheck/stages/unwrap_parens.lua
@@ -50,7 +50,7 @@ local function handle_nodes(chstate, nodes, list_start)
             if node[2] then
                handle_nodes(chstate, node[2])
             end
-         elseif tag == "Set" then
+         elseif tag == "Set" or tag == "OpSet" then
             handle_nodes(chstate, node[1])
             handle_nodes(chstate, node[2], 1)
          else
@@ -67,7 +67,7 @@ local function handle_nodes(chstate, nodes, list_start)
 
             -- warn that not (x == y) can become x ~= y
             if tag == "Op" and node[1] == "not" and node[2].tag == "Op" and relational_operators[node[2][1]] then
-            chstate:warn_range("581", node, {
+               chstate:warn_range("581", node, {
                   operator = relational_operators[node[2][1]],
                   replacement_operator = replacements[node[2][1]]
                })


### PR DESCRIPTION
Fix for #93 

This does fix the repro case I found, and it seems technically better. That said, the failure case was *extremely* basic, so I'm still a bit concerned; but this is definitely an improvement. Changes:
(1) Most places that check against "Set" also need to check against "OpSet"
(1a) When I changed set_variables to check OpSet too, I need to make it note that OpSet also accesses the variable's original value
(1b) This is fine, it won't improperly detect accesses because the later circular reference checker will filter them out... except the circular reference was improperly not detecting OpSet's as circular.
(2) I changed the representation of the OpSet node produced by the parser to match the Set node, such that they can be used by shared code. In particular, OpSet now passes out the lhs/rhs as tables of values rather than single values, even though OpSet doesn't support multiple assignment. Also, I changed the order from {operator, lhs, rhs} to {lhs, rhs, operator} to allow using OpSet nodes wherever Set nodes are used. (Set nodes are {lhs, rhs}.)

I still don't have access to a large crashing codebase, thus the lack of confidence. The first few repos I tested this on, e.g. https://github.com/NobleRobot/NobleEngine, didn't crash even under the previous version.