### PR TITLE
src: support NO_COLOR environment variable

### DIFF
--- a/src/luacheck/format.lua
+++ b/src/luacheck/format.lua
@@ -4,6 +4,8 @@ local utils = require "luacheck.utils"
 local format = {}
 
 local color_support = not utils.is_windows or os.getenv("ANSICON")
+-- Disable colors when NO_COLOR is set, see https://no-color.org/.
+color_support = color_support and not os.getenv("NO_COLOR")
 
 local function get_message_format(warning)
    local message_format = assert(stages.warnings[warning.code], "Unkown warning code " .. warning.code).message_format


### PR DESCRIPTION
NO_COLOR is a de-facto standard environment variable for disabling colors, see [1]:

> Command-line software which adds ANSI color to its output by default
> should check for a NO_COLOR environment variable that, when present and
> not an empty string (regardless of its value), prevents the addition of
> ANSI color.

1. https://no-color.org/