### PR TITLE
ci: drop flaky luajit busted test run

### DIFF
--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit" ] # , "luajit-openresty"
+        luaVersion: [ "5.4", "5.3", "5.2", "5.1"] # , "luajit", "luajit-openresty"
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout


### PR DESCRIPTION
You will need to drop the requirement that all checks pass for this specific pr, since this removed a check.

I cannot reproduce locally; I ssh'd to a running actions container and could reproduce, but couldn't reproduce under gdb. ??? Not worth exploring further, I think.