### PR TITLE
fix: hopefully fix the readthedocs builds (#129)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Recent buildthedocs builds have been failing: https://app.readthedocs.org/projects/luacheck/builds/?utm_source=luacheck&utm_content=flyout

This commit very directly does what the web interface says to do. I didn't test this- readthedocs does have instructions for testing locally, but they didn't work for me.