### PR TITLE
Address some nits that would be helpful for platform builders

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -35,6 +35,8 @@ LFS_A= $(LFS_DIR)/src/lfs.a
 LANES_O= $(patsubst %.c,%.o,$(wildcard $(LANES_DIR)/src/*.c))
 LANES_A= $(LANES_DIR)/src/lanes.a
 
+LUAROCKS?= luarocks
+
 default:	$(TARGET)
 
 $(LUA_DIR):
@@ -47,19 +49,19 @@ $(LFS_DIR):
 	@echo
 	@echo "=== Downloading LuaFileSystem $(LFS_VERSION) ==="
 	@echo
-	luarocks unpack luafilesystem $(LFS_VERSION)
+	$(LUAROCKS) unpack luafilesystem $(LFS_VERSION)
 
 $(ARGPARSE_DIR):
 	@echo
 	@echo "=== Downloading argparse $(ARGPARSE_VERSION) ==="
 	@echo
-	luarocks unpack argparse $(ARGPARSE_VERSION)
+	$(LUAROCKS) unpack argparse $(ARGPARSE_VERSION)
 
 $(LANES_DIR):
 	@echo
 	@echo "=== Downloading Lanes $(LANES_VERSION) ==="
 	@echo
-	luarocks unpack lanes $(LANES_VERSION)
+	$(LUAROCKS) unpack lanes $(LANES_VERSION)
 
 fetch:	$(LUA_DIR) $(LFS_DIR) $(ARGPARSE_DIR) $(LANES_DIR)
 

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -10,9 +10,11 @@ set -o pipefail
 # Should be executed from root Luacheck directory.
 # Resulting binaries will be in `build/bin/`.
 
+: ${MAKE:=make}
+
 cd build
 
-make fetch
+${MAKE} fetch
 
 function build {
     label="$1"
@@ -22,8 +24,8 @@ function build {
     echo "=== Building Luacheck ($label) ==="
     echo
 
-    make clean "$@"
-    make "-j$(nproc)" "$@"
+    ${MAKE} clean "$@"
+    ${MAKE} "-j$(nproc)" "$@"
 }
 
 build "Linux x86-64" LINUX=1

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -11,6 +11,7 @@ set -o pipefail
 # Resulting binaries will be in `build/bin/`.
 
 : ${MAKE:=make}
+: ${CROSSBUILDS=1}
 
 cd build
 
@@ -29,6 +30,8 @@ function build {
 }
 
 build "Linux x86-64" LINUX=1
-#build "Linux x86" LINUX=1 "BASE_CC=gcc -m32" SUFFIX=32
-build "Windows x86-64" CROSS=x86_64-w64-mingw32- SUFFIX=.exe
-build "Windows x86" CROSS=i686-w64-mingw32- SUFFIX=32.exe
+if [ "$CROSSBUILDS" -ne 0 ]; then
+	#build "Linux x86" LINUX=1 "BASE_CC=gcc -m32" SUFFIX=32
+	build "Windows x86-64" CROSS=x86_64-w64-mingw32- SUFFIX=.exe
+	build "Windows x86" CROSS=i686-w64-mingw32- SUFFIX=32.exe
+fi


### PR DESCRIPTION
My main concern here is FreeBSD, though I suspect other platforms would also benefit.  We're currently on an old version based out of the original repo, but I'd quite like to update it- a few env vars that we can set to point at the correct names for the expected programs would be incredibly helpful.