### PR TITLE
fix(Lua 5.5): prevent change on control variable

### DIFF
--- a/src/luacheck/standards.lua
+++ b/src/luacheck/standards.lua
@@ -128,8 +128,8 @@ local function add_fields(def, fields, overwrite, ignore_array_part, default_rea
       return
    end
 
-   for field_name, field_def in pairs(fields) do
-      local field_name = field_name
+   for fn, field_def in pairs(fields) do
+      local field_name = fn
       if type(field_name) == "string" or not ignore_array_part then
          if type(field_name) ~= "string" then
             field_name = field_def

--- a/src/luacheck/standards.lua
+++ b/src/luacheck/standards.lua
@@ -129,6 +129,7 @@ local function add_fields(def, fields, overwrite, ignore_array_part, default_rea
    end
 
    for field_name, field_def in pairs(fields) do
+      local field_name = field_name
       if type(field_name) == "string" or not ignore_array_part then
          if type(field_name) ~= "string" then
             field_name = field_def


### PR DESCRIPTION
## Description

Fixes `luacheck` for Lua 5.5, because there is a change in the control variable at line 135.

@alerque