### PR TITLE
debug: export using gtest

### DIFF
--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -32,7 +32,7 @@ jobs:
           luarocks install luacov-coveralls
 
       - name: Run regression tests
-        run: busted -c -v
+        run: busted -c -v -o gtest
 
       - name: Report test coverage
         if: success()


### PR DESCRIPTION
might shed some light on where it fails when running LuaJIT tests, causing a segfault in CI