### PR TITLE
fix(ci): build LuaJIT using system malloc for lualanes tests

### DIFF
--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -8,16 +8,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit" ] # , "luajit-openresty"
+        luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit" , "luajit-openresty" ]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup ‘lua’
+        if: ${{ !startsWith(matrix.luaVersion, 'luajit') }}
         uses: luarocks/gh-actions-lua@master
         with:
           luaVersion: ${{ matrix.luaVersion }}
+
+      # For the multithreading tests (lanes) to work with
+      # LuaJIT / OpenResty interpreters, we have to build LuaJIT / OpenResty
+      # with the setting `-DLUAJIT_USE_SYSMALLOC` turned on,
+      # because the memory allocator employed by these interpreters
+      # does NOT work well with lanes: see
+      # https://github.com/LuaLanes/lanes/issues/217#issuecomment-1665856470
+      - name: Setup ‘luajit’
+        if: ${{ startsWith(matrix.luaVersion, 'luajit') }}
+        uses: luarocks/gh-actions-lua@master
+        with:
+          luaVersion: ${{ matrix.luaVersion }}
+          luaCompileFlags: XCFLAGS=-DLUAJIT_USE_SYSMALLOC
 
       - name: Setup ‘luarocks’
         uses: luarocks/gh-actions-luarocks@master


### PR DESCRIPTION
## Description

Fix CI tests for LuaJIT / OpenResty + Lanes.

## Details

In the presence of Lanes, for the multithreading tests to work with LuaJIT / OpenResty interpreters, we have to build LuaJIT / OpenResty with the setting `-DLUAJIT_USE_SYSMALLOC` turned on, because the custom memory allocator used by these interpreters does **NOT** work well with Lanes: see [https://github.com/LuaLanes/lanes/issues/217#issuecomment-1665856470](https://github.com/LuaLanes/lanes/issues/217#issuecomment-1665856470)

Special thanks to @arichard4 , @Aire-One and @Tieske to work together at [https://github.com/lunarmodules/luacheck/pull/127](https://github.com/lunarmodules/luacheck/pull/127).

## Notes

1. I was only able to find the root cause of this issue because I already faced problems with LuaJIT / OpenResty allocator in the past on my own specialized modules which require a kind of "stable" allocator (see [https://github.com/luau-project/lua-pcg/blob/1181d0abff74011c676ca6a0695a72562b8e2abd/src/lua-pcg.h#L32-L66](https://github.com/luau-project/lua-pcg/blob/1181d0abff74011c676ca6a0695a72562b8e2abd/src/lua-pcg.h#L32-L66));

2. Before opening this PR, I also tried to configure Lanes (for LuaJIT) forcing a protected allocator as follows

    ```patch
    diff --git a/src/luacheck/multithreading.lua b/src/luacheck/multithreading.lua
    index 55df716..24b797e 100644
    --- a/src/luacheck/multithreading.lua
    +++ b/src/luacheck/multithreading.lua
    @@ -3,7 +3,11 @@ local utils = require "luacheck.utils"
     local multithreading = {}
     
     local lanes_ok, lanes = pcall(require, "lanes")
    -lanes_ok = lanes_ok and pcall(lanes.configure)
    +if type(jit) == "table" then
    +   lanes_ok = lanes_ok and pcall(lanes.configure, { allocator = "protected" })
    +else
    +   lanes_ok = lanes_ok and pcall(lanes.configure)
    +end
     multithreading.has_lanes = lanes_ok
     multithreading.lanes = lanes
     multithreading.default_jobs = 1
    ```

    but it didn't work: see [https://github.com/luau-project/luacheck/actions/runs/24571721549](https://github.com/luau-project/luacheck/actions/runs/24571721549)