### PR TITLE
Add Dependabot for GitHub Actions and pin workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly
+    cooldown:  # https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html
+      default-days: 7

--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup ‘lua’
         if: ${{ !startsWith(matrix.luaVersion, 'luajit') }}
-        uses: luarocks/gh-actions-lua@master
+        uses: luarocks/gh-actions-lua@fc6f8de246f8c01f6e1a56a1b851143e23370ff3 # master
         with:
           luaVersion: ${{ matrix.luaVersion }}
 
@@ -28,13 +28,13 @@ jobs:
       # https://github.com/LuaLanes/lanes/issues/217#issuecomment-1665856470
       - name: Setup ‘luajit’
         if: ${{ startsWith(matrix.luaVersion, 'luajit') }}
-        uses: luarocks/gh-actions-lua@master
+        uses: luarocks/gh-actions-lua@fc6f8de246f8c01f6e1a56a1b851143e23370ff3 # master
         with:
           luaVersion: ${{ matrix.luaVersion }}
           luaCompileFlags: XCFLAGS=-DLUAJIT_USE_SYSMALLOC
 
       - name: Setup ‘luarocks’
-        uses: luarocks/gh-actions-luarocks@master
+        uses: luarocks/gh-actions-luarocks@95d2308a0aff36ad31ebadca493ed14853399842 # master
 
       - name: Setup dependencies
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,12 +5,12 @@ on: [ push, workflow_dispatch ]
 jobs:
 
   affected:
-    uses: lunarmodules/.github/.github/workflows/list_affected_rockspecs.yml@main
+    uses: lunarmodules/.github/.github/workflows/list_affected_rockspecs.yml@5e21af2b298be5ad6677a4737114db239510d3ce # main
 
   build:
     needs: affected
     if: ${{ needs.affected.outputs.rockspecs }}
-    uses: lunarmodules/.github/.github/workflows/test_build_rock.yml@main
+    uses: lunarmodules/.github/.github/workflows/test_build_rock.yml@5e21af2b298be5ad6677a4737114db239510d3ce # main
     with:
       rockspecs: ${{ needs.affected.outputs.rockspecs }}
 
@@ -27,7 +27,7 @@ jobs:
         ( github.ref_name == 'master' || startsWith(github.ref, 'refs/tags/') ) &&
         needs.affected.outputs.rockspecs
       }}
-    uses: lunarmodules/.github/.github/workflows/upload_to_luarocks.yml@main
+    uses: lunarmodules/.github/.github/workflows/upload_to_luarocks.yml@5e21af2b298be5ad6677a4737114db239510d3ce # main
     with:
       rockspecs: ${{ needs.affected.outputs.rockspecs }}
     secrets:
@@ -39,7 +39,7 @@ jobs:
         github.repository == 'lunarmodules/luacheck' &&
         ( github.ref_name == 'master' || startsWith(github.ref, 'refs/tags/') )
       }}
-    uses: lunarmodules/.github/.github/workflows/docker_ghcr_deploy.yml@main
+    uses: lunarmodules/.github/.github/workflows/docker_ghcr_deploy.yml@5e21af2b298be5ad6677a4737114db239510d3ce # main
     with:
       username: ${{ github.actor }}
       tag: ${{ github.ref_name }}

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -25,15 +25,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup ‘lua’
-        uses: luarocks/gh-actions-lua@master
+        uses: luarocks/gh-actions-lua@fc6f8de246f8c01f6e1a56a1b851143e23370ff3 # master
         with:
           luaVersion: ${{ matrix.luaVersion }}
 
       - name: Setup ‘luarocks’
-        uses: luarocks/gh-actions-luarocks@master
+        uses: luarocks/gh-actions-luarocks@95d2308a0aff36ad31ebadca493ed14853399842 # master
 
       - name: Setup dependencies
         run: |

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Update release tags
-        uses: Actions-R-Us/actions-tagger@v2
+        uses: Actions-R-Us/actions-tagger@330ddfac760021349fef7ff62b372f2f691c20fb # v2
         with:
           publish_latest_tag: true


### PR DESCRIPTION
This PR adds Dependabot support for GitHub Actions and pins workflow action references to commit SHAs.

Commits:
1. Add Dependabot config for GitHub Actions (modeled after terminal.lua)
2. Pin workflow actions to commit SHAs and include version/tag comments after each SHA so Dependabot can update both.